### PR TITLE
fix: correctly using `freeze_config.config` in case is not default values

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ Followed is an unmodified [Contributor Covenant Code of Conduct 2.1](https://www
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socioeconomic status,
 nationality, personal appearance, race, religion, or sexual identity
 and orientation.
 

--- a/lua/freeze-code/health.lua
+++ b/lua/freeze-code/health.lua
@@ -160,7 +160,7 @@ local optional_dependencies = {
   },
 }
 
----Check if the package is needed by the platorm
+---Check if the package is needed by the platform
 ---@param pkg FreezeCodeHealthPackage
 ---@return boolean
 local check_platform_needed = function(pkg)

--- a/lua/freeze-code/init.lua
+++ b/lua/freeze-code/init.lua
@@ -323,19 +323,35 @@ freeze_code.freeze = function(s_line, e_line)
 
   freeze_code.config.output = dir .. "/" .. output .. ".png"
 
-  local cmd_args = {
-    "--output",
-    freeze_code.config.output,
-    "--language",
-    lang,
-    "--lines",
-    s_line .. "," .. e_line,
-    "--config",
-    conf,
-    "--theme",
-    theme,
-    file,
-  }
+  local cmd_args = {}
+  if conf == "base" or conf == "full" then
+    cmd_args = {
+      "--output",
+      freeze_code.config.output,
+      "--language",
+      lang,
+      "--lines",
+      s_line .. "," .. e_line,
+      "--config",
+      conf,
+      "--theme",
+      theme,
+      file,
+    }
+  else
+    cmd_args = {
+      "--output",
+      freeze_code.config.output,
+      "--language",
+      lang,
+      "--lines",
+      s_line .. "," .. e_line,
+      "--config",
+      conf,
+      file,
+    }
+  end
+  print(vim.inspect(cmd_args))
 
   commands.job = {}
   commands.job.stdout = vim.loop.new_pipe(false)

--- a/lua/freeze-code/init.lua
+++ b/lua/freeze-code/init.lua
@@ -351,7 +351,6 @@ freeze_code.freeze = function(s_line, e_line)
       file,
     }
   end
-  print(vim.inspect(cmd_args))
 
   commands.job = {}
   commands.job.stdout = vim.loop.new_pipe(false)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list relevant details about your configuration

- [ ] Test A
- [ ] Test B

**Configuration**:

- Neovim version (`nvim --version`):
- Operating system and version:

## Checklist

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I did read the [CODE OF CONDUCT](https://github.com/AlejandroSuero/freeze-code.nvim/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct)
  and I **agree to follow it**.
