### PR TITLE
fix(Commands):  MacOS copy command not working (#12)

### DIFF
--- a/lua/freeze-code/commands.lua
+++ b/lua/freeze-code/commands.lua
@@ -108,7 +108,7 @@ local copy_by_os = function(opts)
     cmd = {
       "osascript",
       "-e",
-      "'set the clipboard to (read (POSIX file \"" .. filename .. "\") as {«class PNGf»})'",
+      'set the clipboard to (read (POSIX file "' .. filename .. '") as {«class PNGf»})',
     }
   end
   if is_unix then


### PR DESCRIPTION
# Description

Removed the unnecessary quote around the argument that is causing a syntax error when running `osascript`. Those quotes aren't needed since vim.system() will not word split the string.

Fixes #12

## Type of change
- Bug fix (non-breaking change which fixes an issue)