### PR TITLE
fix: match os_uname().sysname, not version

### DIFF
--- a/lua/freeze-code/utils/init.lua
+++ b/lua/freeze-code/utils/init.lua
@@ -101,9 +101,9 @@ end
 ---@class FreezeCodeUtils
 ---@field os FreezeCodeOS
 M.os = {
-  is_win = vim.loop.os_uname().version:match("Windows"),
-  is_macos = vim.loop.os_uname().version:match("Darwin"),
-  is_unix = vim.loop.os_uname().version:match("Linux"),
+  is_win = vim.loop.os_uname().sysname:match("Windows"),
+  is_macos = vim.loop.os_uname().sysname:match("Darwin"),
+  is_unix = vim.loop.os_uname().sysname:match("Linux"),
 }
 
 return M


### PR DESCRIPTION
# Description

`:lua vim.print(vim.loop.os_uname())` output:
```lua
{                                                                                                                                                                        
  machine = "x86_64",                                                                                                                                                    
  release = "6.10.6-arch1-1",                                                                                                                                            
  sysname = "Linux",                                                                                                                                                     
  version = "#1 SMP PREEMPT_DYNAMIC Mon, 19 Aug 2024 17:02:39 +0000"                                                                                                     
}   
```
If we try `is_unix = vim.loop.os_uname().version:match("Linux")`, it would be `false`, which is incorrect,  so this PR uses `vim.loop.os_uname().sysname:match("Linux")` instead.

<details>

```lua
-- my plugin setup, use Lazy.nvim
{
    'AlejandroSuero/freeze-code.nvim',
    opts = {
      copy = true,
      dir = vim.fs.normalize('~/usr/Pictures/screenshots'),
    },
    keys = {
      { '<leader>hs', '<cmd>Freeze<CR>' },
    },
}
```

#### Before:
```
-- $ vi foobar.lua
-- hit <leader>hs
-- nvim prints:
{}                                                                                                                                                                       
Error executing vim.schedule lua callback: Vim:E474: Invalid argument                                                                                                    
stack traceback:                                                                                                                                                         
        [C]: in function 'copy_by_os'                                                                                                                                    
        .../lazy_nvim/freeze-code.nvim/lua/freeze-code/commands.lua:134: in function 'copy'                                                                              
        .../lazy_nvim/freeze-code.nvim/lua/freeze-code/commands.lua:53: in function ''                                                                                   
        vim/_editor.lua: in function <vim/_editor.lua:0>                                                                                                                 
Press ENTER or type command to continue            
```
I searched the code base and found this:
```lua
-- lua/freeze-code/commands.lua
local copy_by_os = function(opts)
  local cmd = {}
  local filename = vim.fn.expand(opts.output)

  -- default is "", so we don't go into this branch
  if config.config.copy_cmd ~= "" then
    -- ...
  end
  -- I don't have `gclip` installed, so this neither
  if vim.fn.executable("gclip") ~= 0 then
    cmd = { "gclip", "-copy", "-f", filename }
    return vim.fn.system(cmd)
  end

  -- these 3 variables are all **false**
  if is_win then
    -- ...
  elseif is_macos then
    -- ...
  if is_unix then
    -- ...
  end
  
  -- cmd = {}, so vim raises an error
  return vim.fn.system(cmd)
end

```

</details>

##### Fixes (no issues were found)
```
-- $ vi foobar.lua
-- hit <leader>hs
-- nvim prints:
{}                                                                                                                                                                       
Error executing vim.schedule lua callback: Vim:E474: Invalid argument                                                                                                    
stack traceback:                                                                                                                                                         
        [C]: in function 'copy_by_os'                                                                                                                                    
        .../lazy_nvim/freeze-code.nvim/lua/freeze-code/commands.lua:134: in function 'copy'                                                                              
        .../lazy_nvim/freeze-code.nvim/lua/freeze-code/commands.lua:53: in function ''                                                                                   
        vim/_editor.lua: in function <vim/_editor.lua:0>                                                                                                                 
Press ENTER or type command to continue            
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list relevant details about your configuration

After the change, it would correctly goes into the 3 os branch.
But under wayland, `vim.fn.system { "wl-copy", "<", filename }` would copy literal string: `< [filename].png`. I'll open another PR.


**Configuration**:

- Neovim version (`nvim --version`):
I don't know if this behavior is related to neovim version, anyway I use nightly build.
```
NVIM v0.11.0-dev-672+g3085c9d9da                                                                                                                                         
Build type: Release                                                                                                                                                      
LuaJIT 2.1.1723675123                                                                                                                                                    
Run ":verbose version" for more info  
```
- Operating system and version:
```bash
$ uname -a
Linux arc 6.10.6-arch1-1 #1 SMP PREEMPT_DYNAMIC Mon, 19 Aug 2024 17:02:39 +0000 x86_64 GNU/Linux
```
Arch Linux x86_64, kernel linux-zen, kitty 0.36.1, Hyprland (wayland)

## Checklist

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
   rather simple change, so no comment :)
- [x] I have made corresponding changes to the documentation
   no documentation change is needed
- [x] I did read the [CODE OF CONDUCT](https://github.com/AlejandroSuero/freeze-code.nvim/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct)
  and I **agree to follow it**.
