### PR TITLE
fix: wl-copy copies literal string `< [filename].png`

### DIFF
--- a/lua/freeze-code/commands.lua
+++ b/lua/freeze-code/commands.lua
@@ -121,7 +121,7 @@ local copy_by_os = function(opts)
     if vim.env.XDG_SESSION_TYPE == "x11" then
       cmd = { "xclip", "-selection", "clipboard", "-t", "image/png", "-i", filename }
     else
-      cmd = { "wl-copy", "<", filename }
+      cmd = { "sh", "-c", "wl-copy <" .. filename }
     end
   end
   return vim.fn.system(cmd)


### PR DESCRIPTION

# Description

Under wayland, `vim.fn.system({"wl-copy", "<", "foobar.png"})` would copy literal string `< foobar.png`.

## Solution
wrap it by `vim.fn.system("sh", "-c", "wl-copy < " .. filename)`

## Fixes (no related issues were found)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list relevant details about your configuration

After the change, I could successfully copy the image and paste it elsewhere.

**Configuration**:
- Neovim version (`nvim --version`):
```
NVIM v0.11.0-dev-672+g3085c9d9da                                                                                                                                         
Build type: Release                                                                                                                                                      
LuaJIT 2.1.1723675123                                                                                                                                                    
Run ":verbose version" for more info  
```
- Operating system and version:
```bash
$ uname -a
Linux arc 6.10.6-arch1-1 #1 SMP PREEMPT_DYNAMIC Mon, 19 Aug 2024 17:02:39 +0000 x86_64 GNU/Linux
```
Arch Linux x86_64, kernel linux-zen, kitty 0.36.1, Hyprland (wayland)

## Checklist

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
   rather simple change, so no comment :)
- [x] I have made corresponding changes to the documentation
   no documentation change is needed
- [x] I did read the [CODE OF CONDUCT](https://github.com/AlejandroSuero/freeze-code.nvim/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct)
  and I **agree to follow it**.
