### PR TITLE
Fix: open on linux / xdg-open output's parent dir

### DIFF
--- a/lua/freeze-code/commands.lua
+++ b/lua/freeze-code/commands.lua
@@ -137,6 +137,8 @@ local open_by_os = function(opts)
   local filename = vim.fn.expand(opts.output)
   if is_win then
     cmd = { "explorer", filename }
+  elseif is_unix then
+    cmd = { "xdg-open", vim.fs.dirname(filename) }
   else
     cmd = { "open", filename }
   end


### PR DESCRIPTION
# Description

Just a simple condition branch added to commands/open because this was erroring out  on linux.
No way was set for automatic open if `is_unix` was true. PResumably b/c it is tricky to determine what is the default file manager in variety of linux environments. The best approximation I came up is directing `xdg-open` to parent dir of the output file.  It should open the location in preferred file manager without focusing on the file, but it should be
 enough to improve the flow, rather than simply erroring out.
 
 ## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
_none_
**Configuration**:

- Neovim version (`nvim --version`):
NVIM v0.10.4
Build type: RelWithDebInfo
LuaJIT 2.1.1720049189
Run "nvim -V1 -v" for more info

- Operating system and version:
Fedora Linux 40 Wayland Environment
## Checklist

- [ x] My code follows the style guidelines of this project (stylua)
- [x ] I have performed a self-review of my own code
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~ NOT APPLICABLE/TOO SIMPLISTIC
~~- [ ] I have made corresponding changes to the documentation~~ NOT APPLICABLE
- [ x] I did read the [CODE OF CONDUCT](https://github.com/AlejandroSuero/freeze-code.nvim/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct)
  and I **agree to follow it**.
